### PR TITLE
Allow static min and max via cfg

### DIFF
--- a/asciichartpy/__init__.py
+++ b/asciichartpy/__init__.py
@@ -16,8 +16,8 @@ __all__ = ['plot']
 
 def plot(series, cfg={}):
 
-    minimum = min(series)
-    maximum = max(series)
+    minimum = cfg['minimum'] if 'minimum' in cfg else min(series)
+    maximum = cfg['maximum'] if 'maximum' in cfg else max(series)
 
     interval = abs(float(maximum) - float(minimum))
     offset = cfg['offset'] if 'offset' in cfg else 3


### PR DESCRIPTION
Sometimes auto-scale is just not what you want, you can now just say:
```
cfg['minimum'] = 0
cfg['maximum'] = 100
```
and the scale stays fixed. This is useful when you stream data to plot().