### PR TITLE
Add a title option in the Python version.

### DIFF
--- a/asciichartpy/__init__.py
+++ b/asciichartpy/__init__.py
@@ -61,7 +61,11 @@ def plot(series, cfg=None, title=None):
 
     plot_string = '\n'.join([''.join(row) for row in result])
     if title:
-        n_padding = (plot_string.index('┤') + plot_string.index('\n')) // 2
+        # Center the title over the non-axis portion of the plot.
+        # If the title is too long, start just after axis ends.
+        n_padding = plot_string.index('┤')
+        plot_length = plot_string.index('\n') - plot_string.index('┤')
+        n_padding += max((plot_length - len(title)) // 2, 1)
         title = ' ' * n_padding + title
         plot_string = '\n'.join((title, plot_string))
     return plot_string

--- a/asciichartpy/__init__.py
+++ b/asciichartpy/__init__.py
@@ -22,6 +22,8 @@ def plot(series, cfg=None, title=None):
     interval = abs(float(maximum) - float(minimum))
     offset = cfg['offset'] if 'offset' in cfg else 3
     height = cfg['height'] if 'height' in cfg else interval
+    if title:
+        height -= 1
     ratio = height / interval
     min2 = floor(float(minimum) * ratio)
     max2 = ceil(float(maximum) * ratio)

--- a/asciichartpy/__init__.py
+++ b/asciichartpy/__init__.py
@@ -10,10 +10,10 @@ __all__ = ['plot']
 
 # -----------------------------------------------------------------------------
 
-def plot(series, cfg=None):
+def plot(series, cfg=None, title=None):
     """ Possible cfg parameters are 'minimum', 'maximum', 'offset', 'height' and 'format'.
 	cfg is a dictionary, thus dictionary syntax has to be used.
-	Example: print(plot(series, { 'height' :10 })) 
+	Example: print(plot(series, { 'height' :10 }))
 	"""
     cfg = cfg or {}
     minimum = cfg['minimum'] if 'minimum' in cfg else min(series)
@@ -57,4 +57,9 @@ def plot(series, cfg=None):
             for y in range(start, end):
                 result[rows - y][x + offset] = '│'
 
-    return '\n'.join([''.join(row) for row in result])
+    plot_string = '\n'.join([''.join(row) for row in result])
+    if title:
+        n_padding = (plot_string.index('┤') + plot_string.index('\n')) // 2
+        title = ' ' * n_padding + title
+        plot_string = '\n'.join((title, plot_string))
+    return plot_string

--- a/asciichartpy/__init__.py
+++ b/asciichartpy/__init__.py
@@ -63,9 +63,9 @@ def plot(series, cfg=None, title=None):
     if title:
         # Center the title over the non-axis portion of the plot.
         # If the title is too long, start just after axis ends.
-        n_padding = plot_string.index('┤')
-        plot_length = plot_string.index('\n') - plot_string.index('┤')
-        n_padding += max((plot_length - len(title)) // 2, 1)
+        axis_idx = min(plot_string.index('┤'), plot_string.index('┼'))
+        plot_length = plot_string.index('\n') - axis_idx
+        n_padding = axis_idx + max((plot_length - len(title)) // 2, 1)
         title = ' ' * n_padding + title
         plot_string = '\n'.join((title, plot_string))
     return plot_string

--- a/pplot
+++ b/pplot
@@ -12,10 +12,12 @@ def parse_args():
     parser.add_argument("--format", help="Format for tick numbers.")
     parser.add_argument("--minimum", type=float, help="Min y value.")
     parser.add_argument("--maximum", type=float, help="Max y value.")
+    parser.add_argument("--title")
     return parser.parse_args()
 
 if __name__ == "__main__":
     args = vars(parse_args())
     series = args.pop("series")
+    title = args.pop("title")
     cfg = {k: v for k, v in args.items() if v is not None}
-    print(plot(series, cfg))
+    print(plot(series, cfg, title))


### PR DESCRIPTION
This updates the Python `plot` command and the `pplot` script with an additional `title` argument. If given, the title is the first line of the plot string and is centered over the non-axis region of the plot (unless it's too long, then it starts just after the y-axis ends). If no title is given, the behavior is the same as right now.

Example:

```bash
$ pplot 1 10 5 3 9 7 10 0.1 --title "Title"
            Title
   10.00  ┼╭╮   ╭╮ 
    8.90  ┤││ ╭╮││ 
    7.80  ┤││ ││││ 
    6.70  ┤││ │╰╯│ 
    5.60  ┤││ │  │ 
    4.50  ┤│╰╮│  │ 
    3.40  ┤│ ╰╯  │ 
    2.30  ┤│     │ 
    1.20  ┤╯     │ 
    0.10  ┼      ╰ 
```

Note: if there is a title, I decrease the height allotted for the rest of the plot by 1. This means that the rest of the plot will look a little different (the axis values change; see an example below). If you'd prefer, we could leave the height the same and just note (e.g. in the doc string) that a plot with a title will have a height that is 1 larger.

```bash
$ pplot 1 10 5 3 9 7 10 0.1
   10.00  ┼╭╮   ╭╮ 
    9.01  ┤││ ╭╮││ 
    8.02  ┤││ ││││ 
    7.03  ┤││ │╰╯│ 
    6.04  ┤││ │  │ 
    5.05  ┤│╰╮│  │ 
    4.06  ┤│ ││  │ 
    3.07  ┤│ ╰╯  │ 
    2.08  ┤│     │ 
    1.09  ┼╯     │ 
    0.10  ┤      ╰ 
```