### PR TITLE
Fix for exact specification of plot height.

### DIFF
--- a/asciichartpy/__init__.py
+++ b/asciichartpy/__init__.py
@@ -2,6 +2,7 @@
 
 # -----------------------------------------------------------------------------
 
+from __future__ import division
 from math import ceil, floor
 
 # -----------------------------------------------------------------------------
@@ -13,40 +14,39 @@ __all__ = ['plot']
 def plot(series, cfg=None):
     """ Possible cfg parameters are 'minimum', 'maximum', 'offset', 'height' and 'format'.
 	cfg is a dictionary, thus dictionary syntax has to be used.
-	Example: print(plot(series, { 'height' :10 })) 
+	Example: print(plot(series, { 'height' :10 }))
 	"""
     cfg = cfg or {}
     minimum = cfg['minimum'] if 'minimum' in cfg else min(series)
     maximum = cfg['maximum'] if 'maximum' in cfg else max(series)
+    if minimum > maximum:
+        raise ValueError('The minimum value cannot exceed the maximum value.')
 
-    interval = abs(float(maximum) - float(minimum))
+    interval = maximum - minimum
     offset = cfg['offset'] if 'offset' in cfg else 3
     height = cfg['height'] if 'height' in cfg else interval
     ratio = height / interval
-    min2 = floor(float(minimum) * ratio)
-    max2 = ceil(float(maximum) * ratio)
+    min2 = floor(minimum * ratio)
+    max2 = ceil(maximum * ratio)
 
-    intmin2 = int(min2)
-    intmax2 = int(max2)
-
-    rows = abs(intmax2 - intmin2)
+    rows = max2 - min2
     width = len(series) + offset
     placeholder = cfg['format'] if 'format' in cfg else '{:8.2f} '
 
     result = [[' '] * width for i in range(rows + 1)]
 
     # axis and labels
-    for y in range(intmin2, intmax2 + 1):
-        label = placeholder.format(float(maximum) - ((y - intmin2) * interval / rows))
-        result[y - intmin2][max(offset - len(label), 0)] = label
-        result[y - intmin2][offset - 1] = '┼' if y == 0 else '┤'
+    for y in range(min2, max2 + 1):
+        label = placeholder.format(maximum - ((y - min2) * interval / rows))
+        result[y - min2][max(offset - len(label), 0)] = label
+        result[y - min2][offset - 1] = '┼' if y == 0 else '┤'
 
     y0 = int(series[0] * ratio - min2)
     result[rows - y0][offset - 1] = '┼' # first value
 
-    for x in range(0, len(series) - 1): # plot the line
-        y0 = int(round(series[x + 0] * ratio) - intmin2)
-        y1 = int(round(series[x + 1] * ratio) - intmin2)
+    for x in range(len(series) - 1): # plot the line
+        y0 = round(series[x + 0] * ratio) - min2
+        y1 = round(series[x + 1] * ratio) - min2
         if y0 == y1:
             result[rows - y0][x + offset] = '─'
         else:

--- a/asciichartpy/__init__.py
+++ b/asciichartpy/__init__.py
@@ -24,37 +24,33 @@ def plot(series, cfg=None):
 
     interval = maximum - minimum
     offset = cfg['offset'] if 'offset' in cfg else 3
-    height = cfg['height'] if 'height' in cfg else interval
-    ratio = height / interval
-    min2 = floor(minimum * ratio)
-    max2 = ceil(maximum * ratio)
-
-    rows = max2 - min2
+    height = cfg['height'] if 'height' in cfg else ceil(interval)
+    ratio = interval / (height - 1)
     width = len(series) + offset
     placeholder = cfg['format'] if 'format' in cfg else '{:8.2f} '
 
-    result = [[' '] * width for i in range(rows + 1)]
+    result = [[' '] * width for i in range(height)]
 
     # axis and labels
-    for y in range(min2, max2 + 1):
-        label = placeholder.format(maximum - ((y - min2) * interval / rows))
-        result[y - min2][max(offset - len(label), 0)] = label
-        result[y - min2][offset - 1] = '┼' if y == 0 else '┤'
+    for i in range(height):
+        label = placeholder.format(minimum + i * ratio)
+        result[i][max(offset - len(label), 0)] = label
+        result[i][offset - 1] = '┼' if i == 0 else '┤'
 
-    y0 = int(series[0] * ratio - min2)
-    result[rows - y0][offset - 1] = '┼' # first value
+    y0 = int((series[0] - minimum) / ratio)
+    result[y0][offset - 1] = '┼' # first value
 
-    for x in range(len(series) - 1): # plot the line
-        y0 = round(series[x + 0] * ratio) - min2
-        y1 = round(series[x + 1] * ratio) - min2
+    for i in range(len(series) - 1): # plot the line
+        y0 = round((series[i] - minimum) / ratio)
+        y1 = round((series[i + 1] - minimum) / ratio)
         if y0 == y1:
-            result[rows - y0][x + offset] = '─'
+            result[y0][i + offset] = '─'
         else:
-            result[rows - y1][x + offset] = '╰' if y0 > y1 else '╭'
-            result[rows - y0][x + offset] = '╮' if y0 > y1 else '╯'
+            result[y1][i + offset] = '╰' if y0 > y1 else '╭'
+            result[y0][i + offset] = '╮' if y0 > y1 else '╯'
             start = min(y0, y1) + 1
             end = max(y0, y1)
             for y in range(start, end):
-                result[rows - y][x + offset] = '│'
+                result[y][i + offset] = '│'
 
-    return '\n'.join([''.join(row) for row in result])
+    return '\n'.join([''.join(row) for row in result[::-1]])

--- a/pplot
+++ b/pplot
@@ -8,7 +8,7 @@ def parse_args():
     parser = ArgumentParser()
     parser.add_argument("series", type=float, nargs="+")
     parser.add_argument("--offset", type=int)
-    parser.add_argument("--height", type=float)
+    parser.add_argument("--height", type=int)
     parser.add_argument("--format", help="Format for tick numbers.")
     parser.add_argument("--minimum", type=float, help="Min y value.")
     parser.add_argument("--maximum", type=float, help="Max y value.")


### PR DESCRIPTION
Fixes #26.

This changes a bit of the logic for making the plot, some of which wasn't really necessary but made it easier / less confusing for me to work on it. `ratio` is the reciprocal of what it was before (it's now the change in y when you move up one row in the plot). The plot is stored in reverse order compared to before when in list form (e.g. `result[0]` is now the bottom row of the plot instead of the top one; I reverse the rows before joining them into the final plot string to make up for this). The actual change is a rework to how we convert from the data space to the row space of the plot which makes it (IMHO) less complex (removes `max2` and `min2`) and easy to guarantee exactly what the height is. 

**Caveats**
* I didn't understand why `max2` and `min2` were needed before instead of working with `maximum` and `minimum` directly, as I do in this version. Is there some drawback to the method I use here that I'm missing?
* I also wasn't quite clear on when you wanted to use '┼' vs '┤'; I think that part might not be the same now. I should be able to update that quickly if you can explain to me when you want '┼' used (it seems you use it for the y-value of the first data point, which I kept, but I wasn't clear on the second condition for it).

(#28 should be merged before this one, which starts from the cleaned up Python code; I was working on a few different things in parallel, but it got to be a pain to have all the PRs completely independent. Just look at the second commit to see the changes that this PR introduces).