### PR TITLE
Fix position of initial point on y-axis

### DIFF
--- a/asciichartpy/__init__.py
+++ b/asciichartpy/__init__.py
@@ -41,7 +41,7 @@ def plot(series, cfg=None):
         result[y - min2][max(offset - len(label), 0)] = label
         result[y - min2][offset - 1] = '┼' if y == 0 else '┤'
 
-    y0 = int(series[0] * ratio - min2)
+    y0 = round(series[0] * ratio - min2)
     result[rows - y0][offset - 1] = '┼' # first value
 
     for x in range(len(series) - 1): # plot the line


### PR DESCRIPTION
In the Python version of asciichart, the position of the first tick mark
is sometimes drawn incorrectly due to a rounding error. The value should
be `round` up, but the `int` function is used instead.

Before the change (the tick mark on the y-axis is at 4.5, but it
should be at 6.25):

    > python3 ./pplot --height 3 6 1 8
    >     8.00  ┼
    >     6.25  ┤╮╭
    >     4.50  ┼││
    >     2.75  ┤││
    >     1.00  ┤╰╯

After the change:

    > python3 ./pplot --height 3 6 1 8
    >     8.00  ┼
    >     6.25  ┼╮╭
    >     4.50  ┤││
    >     2.75  ┤││
    >     1.00  ┤╰╯

Note: this bug is not in the node version.