### PR TITLE
Add support for multiple data series in Python version

### DIFF
--- a/asciichartpy/__init__.py
+++ b/asciichartpy/__init__.py
@@ -75,7 +75,24 @@ def plot(series, cfg=None):
               30 ┤ ╭╯  ╰╮
               20 ┤╭╯    ╰╮
               10 ┼╯      ╰
+
+    `color` is a list of ANSI escape sequences to colour the plot line on the
+    graph. ANSI colours must be specified in the same order as the data series
+    being plotted (when using multiple series). The colour list must contain
+    an extra entry on the end which must be the clear/blanking ANSI colour
+    code. If a single data series is being used, only one colour code needs to
+    be provided in addition to the escape code. If no colours are provided the
+    default terminal colour is used.
+
+        >>> series = [10,20,30,40,50,40,30,20,10]
+        >>> print(plot(series, {'height': 4, 'colors': ['\033[94m', '\033[0m']}))
+           50.00  ┼   ╭╮
+           37.50  ┤  ╭╯╰╮
+           25.00  ┤╭─╯  ╰─╮
+           12.50  ┼╯      ╰
+            0.00  ┤
 	"""
+
     if len(series) == 0:
         return ''
 
@@ -96,6 +113,7 @@ def plot(series, cfg=None):
 
     default_symbols = ['┼', '┤', '╶', '╴', '─', '╰', '╭', '╮', '╯', '│']
     symbols = cfg.get('symbols', default_symbols)
+    colors = cfg.get('colors', ['\033[0m' for i in range(0, len(series)+1)])
 
     if minimum > maximum:
         raise ValueError('The minimum value cannot exceed the maximum value.')
@@ -147,25 +165,25 @@ def plot(series, cfg=None):
                 continue
 
             if isnan(d0) and _isnum(d1):
-                result[rows - scaled(d1)][x + offset] = symbols[2]
+                result[rows - scaled(d1)][x + offset] = colors[i] + symbols[2] + colors[-1]
                 continue
 
             if _isnum(d0) and isnan(d1):
-                result[rows - scaled(d0)][x + offset] = symbols[3]
+                result[rows - scaled(d0)][x + offset] = colors[i] + symbols[3] + colors[-1]
                 continue
 
             y0 = scaled(d0)
             y1 = scaled(d1)
             if y0 == y1:
-                result[rows - y0][x + offset] = symbols[4]
+                result[rows - y0][x + offset] = colors[i] + symbols[4] + colors[-1]
                 continue
 
-            result[rows - y1][x + offset] = symbols[5] if y0 > y1 else symbols[6]
-            result[rows - y0][x + offset] = symbols[7] if y0 > y1 else symbols[8]
+            result[rows - y1][x + offset] = (colors[i] + symbols[5] + colors[-1]) if y0 > y1 else (colors[i] + symbols[6] + colors[-1])
+            result[rows - y0][x + offset] = (colors[i] + symbols[7] + colors[-1]) if y0 > y1 else (colors[i] + symbols[8] + colors[-1])
 
             start = min(y0, y1) + 1
             end = max(y0, y1)
             for y in range(start, end):
-                result[rows - y][x + offset] = symbols[9]
+                result[rows - y][x + offset] = colors[i] + symbols[9] + colors[-1]
 
     return '\n'.join([''.join(row).rstrip() for row in result])

--- a/asciichartpy/__init__.py
+++ b/asciichartpy/__init__.py
@@ -79,7 +79,7 @@ def plot(series, cfg=None):
     if len(series) == 0:
         return ''
 
-    if isinstance(series[0], int):
+    if not isinstance(series[0], list):
         if all(isnan(n) for n in series):
             return ''
         else:


### PR DESCRIPTION
This pull request adds support for multiple data series in the Python version, which is currently missing but is present in the JS version.

This is the test script I'm using:

```
(asciichart)$cat jb.py 

#!/usr/bin/env python3

import asciichartpy
import random
from time import sleep

InMbps = [random.randint(-100, 0) for x in range(1, 60)]
OutMbps = [random.randint(100, 200) for x in range(1, 60)]

while True:

    print("\033[H\033[J", end='') # clear screen

    config = {
        "height": 20,
    }

    for i in range(0, len(InMbps)-1):
        InMbps[i] = InMbps[i+1]
    InMbps[-1] = random.randint(-100, 0)

    for i in range(0, len(OutMbps)-1):
        OutMbps[i] = OutMbps[i+1]
    OutMbps[-1] = random.randint(100, 200)

    print(asciichartpy.plot([InMbps, OutMbps], config))
    sleep(1)
```

Output can be seen here to prove it's working: https://i.imgur.com/97hPiq9.png

Also running the test script test.py works as expected, as can be seen here: https://i.imgur.com/B9252nB.png
