### PR TITLE
Add support for multiple data series in Python version (v2)

### DIFF
--- a/asciichartpy/__init__.py
+++ b/asciichartpy/__init__.py
@@ -43,22 +43,22 @@ def plot(series, cfg=None):
            10.00  ┼╯ ╰╯ ╰
 
     `cfg` is an optional dictionary of various parameters to tune the appearance
-    of the chart. `minimum` and `maximum` will clamp the y-axis and all values:
+    of the chart. `min` and `max` will clamp the y-axis and all values:
 
         >>> series = [1,2,3,4,float("nan"),4,3,2,1]
-        >>> print(plot(series, {'minimum': 0}))
+        >>> print(plot(series, {'min': 0}))
             4.00  ┼  ╭╴╶╮
             3.00  ┤ ╭╯  ╰╮
             2.00  ┤╭╯    ╰╮
             1.00  ┼╯      ╰
             0.00  ┤
 
-        >>> print(plot(series, {'minimum': 2}))
+        >>> print(plot(series, {'min': 2}))
             4.00  ┤  ╭╴╶╮
             3.00  ┤ ╭╯  ╰╮
             2.00  ┼─╯    ╰─
 
-        >>> print(plot(series, {'minimum': 2, 'maximum': 3}))
+        >>> print(plot(series, {'min': 2, 'max': 3}))
             3.00  ┤ ╭─╴╶─╮
             2.00  ┼─╯    ╰─
 
@@ -96,14 +96,14 @@ def plot(series, cfg=None):
 
     cfg = cfg or {}
 
-    minimum = cfg.get('minimum', min(filter(_isnum, [j for i in series for j in i])))
-    maximum = cfg.get('maximum', max(filter(_isnum, [j for i in series for j in i])))
+    minimum = cfg.get('min', min(filter(_isnum, [j for i in series for j in i])))
+    maximum = cfg.get('max', max(filter(_isnum, [j for i in series for j in i])))
 
     default_symbols = ['┼', '┤', '╶', '╴', '─', '╰', '╭', '╮', '╯', '│']
     symbols = cfg.get('symbols', default_symbols)
 
     if minimum > maximum:
-        raise ValueError('The minimum value cannot exceed the maximum value.')
+        raise ValueError('The min value cannot exceed the max value.')
 
     interval = maximum - minimum
     offset = cfg.get('offset', 3)

--- a/asciichartpy/__init__.py
+++ b/asciichartpy/__init__.py
@@ -33,6 +33,15 @@ def plot(series, cfg=None):
             2.00  ┤╭╯    ╰╮
             1.00  ┼╯      ╰
 
+    `series` can also be a list of lists to support multiple data series.
+
+        >>> series = [[10,20,30,40,30,20,10], [40,30,20,10,20,30,40]]
+        >>> print(plot(series, {'height': 3}))
+           40.00  ┤╮ ╭╮ ╭
+           30.00  ┤╰╮╯╰╭╯
+           20.00  ┤╭╰╮╭╯╮
+           10.00  ┼╯ ╰╯ ╰
+
     `cfg` is an optional dictionary of various parameters to tune the appearance
     of the chart. `minimum` and `maximum` will clamp the y-axis and all values:
 
@@ -75,7 +84,7 @@ def plot(series, cfg=None):
               30 ┤ ╭╯  ╰╮
               20 ┤╭╯    ╰╮
               10 ┼╯      ╰
-	"""
+    """
     if len(series) == 0:
         return ''
 
@@ -86,13 +95,9 @@ def plot(series, cfg=None):
             series = [series]
 
     cfg = cfg or {}
-    minimum = cfg.get('minimum', 0)
-    maximum = cfg.get('maximum', 0)
 
-    for i in range(0, len(series)):
-        for j in range(0, len(series[i])):
-            minimum = min(minimum, series[i][j])
-            maximum = max(maximum, series[i][j])
+    minimum = cfg.get('minimum', min(filter(_isnum, [j for i in series for j in i])))
+    maximum = cfg.get('maximum', max(filter(_isnum, [j for i in series for j in i])))
 
     default_symbols = ['┼', '┤', '╶', '╴', '─', '╰', '╭', '╮', '╯', '│']
     symbols = cfg.get('symbols', default_symbols)

--- a/asciichartpy/__init__.py
+++ b/asciichartpy/__init__.py
@@ -79,7 +79,7 @@ def plot(series, cfg=None):
     if len(series) == 0:
         return ''
 
-    if isinstance(series[0], int):
+    if not isinstance(series[0], list):
         if all(isnan(n) for n in series):
             return ''
         else:


### PR DESCRIPTION
This pull request adds support for multiple data series in the Python version, which is currently missing but is present in the JS version.

This is the test script I'm using:

```
(asciichart)$cat jb.py 

#!/usr/bin/env python3

import asciichartpy
import random
from time import sleep

InMbps = [random.randint(-100, 0) for x in range(1, 60)]
OutMbps = [random.randint(100, 200) for x in range(1, 60)]

while True:

    print("\033[H\033[J", end='') # clear screen

    config = {
        "height": 20,
    }

    for i in range(0, len(InMbps)-1):
        InMbps[i] = InMbps[i+1]
    InMbps[-1] = random.randint(-100, 0)

    for i in range(0, len(OutMbps)-1):
        OutMbps[i] = OutMbps[i+1]
    OutMbps[-1] = random.randint(100, 200)

    print(asciichartpy.plot([InMbps, OutMbps], config))
    sleep(1)
```

Output can be seen here to prove it's working: https://i.imgur.com/97hPiq9.png

Also running the test script test.py works as expected, as can be seen here: https://i.imgur.com/B9252nB.png