### PR TITLE
Specify y-axis min/max hints

### DIFF
--- a/asciichart.js
+++ b/asciichart.js
@@ -38,8 +38,10 @@
             series = [series]
         }
 
-        let min = series[0][0]
-        let max = series[0][0]
+        cfg = (typeof cfg !== 'undefined') ? cfg : {}
+
+        let min = (typeof cfg.min !== 'undefined') ? cfg.min : series[0][0]
+        let max = (typeof cfg.max !== 'undefined') ? cfg.max : series[0][0]
 
         for (let j = 0; j < series.length; j++) {
             for (let i = 0; i < series[j].length; i++) {
@@ -50,7 +52,6 @@
 
         let defaultSymbols = [ '┼', '┤', '╶', '╴', '─', '╰', '╭', '╮', '╯', '│' ]
         let range   = Math.abs (max - min)
-        cfg         = (typeof cfg !== 'undefined') ? cfg : {}
         let offset  = (typeof cfg.offset  !== 'undefined') ? cfg.offset  : 3
         let padding = (typeof cfg.padding !== 'undefined') ? cfg.padding : '           '
         let height  = (typeof cfg.height  !== 'undefined') ? cfg.height  : range

--- a/test.js
+++ b/test.js
@@ -30,6 +30,13 @@ for (var i = 0; i < width; i++)
 console.log (asciichart.plot (s, config)) // this rescales the graph to ±3 lines
 
 console.log (line)
+console.log ("\configuring y-axis bounds and symbols\n")
+config.min = -20;
+config.max = 20;
+config.symbols = [ '┣', '┣', '╶', '╴', '─', '╰', '╭', '╮', '╯', '│' ];
+console.log (asciichart.plot (s, config));
+
+console.log (line)
 console.log ("auto-range\n")
 
 var s2 = new Array (width)


### PR DESCRIPTION
This is for cases when the chart needs a y-axis min smaller than, or a max larger than, the bounds of the series.

For example, it's quite common to want the chart to have a 0 value on the y-axis, regardless of the data. Also being able to specify the max gives the caller a chance to create a range that has 'sensible' rounded tick values on the y-axis.